### PR TITLE
Fixing filepath of MyBinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="logo.png" width="200"> - How to work with meteorological data
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ecmwf/notebook-examples/master?filepath=%2Fhome%2Fjovyan)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ecmwf/notebook-examples/master/)
 
 The examples in this space should give you a good starting point how you can work with ECMWF services and data through Python using Jupyter notebooks. 
 


### PR DESCRIPTION
The current filepath of MyBinder url of README.md is forwarding to a wrong web page. The purposed solution fix this problem and start a jupyter lab at the main folder of the repository.